### PR TITLE
Sk haschildren

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     </parent>
 
     <artifactId>tapis-security</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
     <packaging>pom</packaging>
 
     <name>TACC Tapis Security Kernel Parent POM</name>

--- a/tapis-securityapi/CHANGELOG.md
+++ b/tapis-securityapi/CHANGELOG.md
@@ -9,6 +9,12 @@ You may also reference live-docs based on the openapi specification here:
 https://tapis-project.github.io/live-docs
 
 -----------------------
+## 1.6.1 - 2024-02-28
+
+### New Features:
+1. Recursive query optimization using new sk_roles.has_children column. 
+
+-----------------------
 ## 1.6.0 - 2024-01-24
 
 ### New Features:

--- a/tapis-securityapi/pom.xml
+++ b/tapis-securityapi/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>edu.utexas.tacc.tapis</groupId>
 		<artifactId>tapis-security</artifactId>
-		<version>1.6.0</version>
+		<version>1.6.1</version>
 	</parent>
 	
 	<artifactId>tapis-securityapi</artifactId>

--- a/tapis-securityapi/src/main/java/edu/utexas/tacc/tapis/security/api/utils/TenantInit.java
+++ b/tapis-securityapi/src/main/java/edu/utexas/tacc/tapis/security/api/utils/TenantInit.java
@@ -4,11 +4,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.utexas.tacc.tapis.security.authz.impl.RoleImpl;
 import edu.utexas.tacc.tapis.security.authz.impl.UserImpl;
 import edu.utexas.tacc.tapis.security.config.RuntimeParameters;
 import edu.utexas.tacc.tapis.shared.TapisConstants;
@@ -290,13 +289,13 @@ public final class TenantInit
     	// We just log and return any error.
     	try {
         	// Query for the assignment of tenant_definition_updater to tokens.
-        	List<Pair<Integer,String>> roleRecs = null;
+        	List<Triple<Integer,String,Boolean>> roleRecs = null;
 			roleRecs = UserImpl.getInstance().getUserRoleIdsAndNames(siteAdminTenant, tokenSvc);
     	
 			// Determine if the tokens service is already assigned the updater role.
 			// If the role is already assigned directly to tokens, there's no work to do.
 			for (var rec: roleRecs) 
-				if (SK_TENANT_UPDATER_ROLE.equals(rec.getRight())) {
+				if (SK_TENANT_UPDATER_ROLE.equals(rec.getMiddle())) {
 					_log.info(MsgUtils.getMsg("SK_TENANT_UPDATER_FOUND", siteAdminTenant,
 							                  tokenSvc, SK_TENANT_UPDATER_ROLE));
 					return; // role already assigned

--- a/tapis-securitylib/pom.xml
+++ b/tapis-securitylib/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>edu.utexas.tacc.tapis</groupId>
 		<artifactId>tapis-security</artifactId>
-		<version>1.6.0</version>
+		<version>1.6.1</version>
 	</parent>
 	
 	<artifactId>tapis-securitylib</artifactId>

--- a/tapis-securitylib/shaded-pom.xml
+++ b/tapis-securitylib/shaded-pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>edu.utexas.tacc.tapis</groupId>
 		<artifactId>tapis-security</artifactId>
-		<version>1.6.0</version>
+		<version>1.6.1</version>
 	</parent>
 	
     <artifactId>tapis-shaded-securitylib</artifactId>

--- a/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/dao/SkRoleDao.java
+++ b/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/dao/SkRoleDao.java
@@ -1011,7 +1011,7 @@ public final class SkRoleDao
    * @return a non-null, ordered list of permissions
    * @throws TapisException on error
    */
-  public List<String> getImmediatePermissions(String tenantId, int roleId) 
+  public List<String> getImmediatePermissions(String tenantId, int roleId, boolean ordered) 
     throws TapisException
   {
       // Initialize result list.
@@ -1025,7 +1025,9 @@ public final class SkRoleDao
           conn = getConnection();
           
           // Get the select command.
-          String sql = SqlStatements.ROLE_GET_IMMEDIATE_PERMISSIONS;
+          String sql;
+          if (ordered) sql = SqlStatements.ROLE_GET_IMMEDIATE_PERMISSIONS;
+            else sql = SqlStatements.ROLE_GET_IMMEDIATE_PERMISSIONS_UNORDERED;
           
           // Prepare the statement and fill in the placeholders.
           PreparedStatement pstmt = conn.prepareStatement(sql);

--- a/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/dao/SkRoleDao.java
+++ b/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/dao/SkRoleDao.java
@@ -1260,6 +1260,7 @@ public final class SkRoleDao
         obj.setUpdated(rs.getTimestamp(10).toInstant());
         obj.setUpdatedby(rs.getString(11));
         obj.setUpdatedbyTenant(rs.getString(12));
+        obj.setHasChildren(rs.getBoolean(13));
     } 
     catch (Exception e) {
       String msg = MsgUtils.getMsg("DB_TYPE_CAST_ERROR", e.getMessage());

--- a/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/dao/SkRoleTreeDao.java
+++ b/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/dao/SkRoleTreeDao.java
@@ -689,7 +689,7 @@ public final class SkRoleTreeDao
      try
      {
          // Get the select command.
-         String sql = SqlStatements.ROLE_GET_CHILD_COUNT;
+         String sql = SqlStatements.ROLE_GET_CHILD_INDICATOR;
          
          // Prepare the statement and fill in the placeholders.
          PreparedStatement pstmt = conn.prepareStatement(sql);
@@ -711,15 +711,8 @@ public final class SkRoleTreeDao
          throw new TapisException(msg, e);
      }
      
-     // Make sure we found the child indicator.
-     if (numChildren < 0) {
-         String msg = MsgUtils.getMsg("SK_ROLE_GET_CHILD_COUNT_ERROR", tenant, parentRoleId, "NO COUNT RETURNED");
-         _log.error(msg);
-         throw new TapisException(msg);
-     }
-     
      // Determine if we need to update the has_children flag in the parent role,
      // which is only necessary when transitioning has_children from true to false.
-     if (numChildren == 0) updateParentHasChildren(conn, tenant, parentRoleId, false);
+     if (numChildren < 1) updateParentHasChildren(conn, tenant, parentRoleId, false);
   }
 }

--- a/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/dao/sql/SqlStatements.java
+++ b/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/dao/sql/SqlStatements.java
@@ -158,8 +158,8 @@ public class SqlStatements
       "order by r.name";
   
   // Get the number of child roles a parent role has.
-  public static final String ROLE_GET_CHILD_COUNT =
-	  "SELECT count(*) FROM sk_role_tree WHERE tenant = ? AND parent_role_id = ?";
+  public static final String ROLE_GET_CHILD_INDICATOR =
+	  "SELECT 1 FROM sk_role_tree WHERE tenant = ? AND parent_role_id = ? LIMIT 1";
   
   // This recursive query retrieves all the roles names that are descendants
   // of the specified role (the role whose id parameter is passed in).  The

--- a/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/dao/sql/SqlStatements.java
+++ b/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/dao/sql/SqlStatements.java
@@ -67,7 +67,8 @@ public class SqlStatements
   public static final String SELECT_ALL_PERMISSIONS =
       "SELECT id, tenant, role_id, permission, created, createdby, createdby_tenant, " 
       + "updated, updatedby, updatedby_tenant "
-      + "FROM sk_role_permission";
+      + "FROM sk_role_permission "
+      + "ORDER BY tenant, permission";
   
   // The following select statement grabs the role id from the sk_role table after 
   // guaranteeing that the role's tenant is the expected one.    
@@ -104,11 +105,18 @@ public class SqlStatements
   public static final String UPDATE_PERMISSION_BY_ID = 
       "UPDATE sk_role_permission SET permission = ? WHERE tenant = ? and id = ?";
   
+  // Get the permission assigned directly to a role (non-transitive) in order.
   public static final String ROLE_GET_IMMEDIATE_PERMISSIONS =
       "SELECT permission "
       + "FROM sk_role_permission "
       + "WHERE tenant = ? AND role_id = ? "
       + "ORDER BY permission";
+
+  // Get the permission assigned directly to a role (non-transitive) unordered.
+  public static final String ROLE_GET_IMMEDIATE_PERMISSIONS_UNORDERED =
+      "SELECT permission "
+      + "FROM sk_role_permission "
+      + "WHERE tenant = ? AND role_id = ? ";
 
   /* ---------------------------------------------------------------------- */
   /* sk_role_tree:                                                          */
@@ -250,7 +258,8 @@ public class SqlStatements
 
   // Get the role ids directly (non-transitively) assigned to user.
   public static final String USER_SELECT_ROLE_IDS =
-      "SELECT role_id FROM sk_user_role WHERE tenant = ? and user_name = ?";
+      "SELECT ur.role_id, r.has_children FROM sk_user_role ur, sk_role r " +
+      "WHERE ur.role_id = r.id and tenant = ? and user_name = ?";
   
   // Get the role ids and the role names directly (non-transitively) assigned to user.
   public static final String USER_SELECT_ROLE_IDS_AND_NAMES =

--- a/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/impl/RoleImpl.java
+++ b/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/impl/RoleImpl.java
@@ -229,16 +229,18 @@ public final class RoleImpl
         
         // Get requested set of permission.
         List<String> perms = null;
-        if (immediate || !role.hasChildren()) 
+        if (immediate || !role.hasChildren()) {
             try {perms = role.getImmediatePermissions();}
             catch (Exception e) {
                 throw new TapisImplException(e.getMessage(), e, Condition.INTERNAL_SERVER_ERROR);
             }
-        else 
+        }
+        else {
             try {perms = role.getTransitivePermissions();}
             catch (Exception e) {
                 throw new TapisImplException(e.getMessage(), e, Condition.INTERNAL_SERVER_ERROR);
             }
+        }
         return perms;
     }
     

--- a/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/impl/RoleImpl.java
+++ b/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/impl/RoleImpl.java
@@ -229,7 +229,7 @@ public final class RoleImpl
         
         // Get requested set of permission.
         List<String> perms = null;
-        if (immediate) 
+        if (immediate || !role.hasChildren()) 
             try {perms = role.getImmediatePermissions();}
             catch (Exception e) {
                 throw new TapisImplException(e.getMessage(), e, Condition.INTERNAL_SERVER_ERROR);

--- a/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/impl/UserImpl.java
+++ b/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/impl/UserImpl.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -429,7 +430,7 @@ public final class UserImpl
      * @return pairs of <roleId, roleName> for each role directly assigned to user
      * @throws TapisImplException
      */
-    public List<Pair<Integer,String>> getUserRoleIdsAndNames(String tenant, String user) 
+    public List<Triple<Integer,String,Boolean>> getUserRoleIdsAndNames(String tenant, String user) 
      throws TapisImplException
     {
         // Get the dao.
@@ -441,15 +442,15 @@ public final class UserImpl
                 throw new TapisImplException(e.getMessage(), e, Condition.INTERNAL_SERVER_ERROR);             }
 
         // Get the user's role names including those assigned transitively.
-        List<Pair<Integer,String>> pairs = null;
-        try {pairs = dao.getUserRoleIdsAndNames(tenant, user);}
+        List<Triple<Integer,String,Boolean>> triples = null;
+        try {triples = dao.getUserRoleIdsAndNames(tenant, user);}
             catch (Exception e) {
                 String msg = MsgUtils.getMsg("SK_USER_GET_ROLE_NAMES_ERROR", 
                                              tenant, user, e.getMessage());
                 _log.error(msg, e);
                 throw new TapisImplException(msg, e, Condition.BAD_REQUEST);            }
         
-        return pairs;
+        return triples;
     }
     
     /* ---------------------------------------------------------------------- */

--- a/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/model/SkRole.java
+++ b/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/model/SkRole.java
@@ -30,7 +30,8 @@ public final class SkRole
     private String  createdbyTenant;
     private Instant updated;
     private String  updatedby;
-    private String  updatedbyTenant;    
+    private String  updatedbyTenant;
+    private boolean hasChildren;
 
     @Override
     public String toString() {return TapisUtils.toString(this);}
@@ -326,5 +327,13 @@ public final class SkRole
 
 	public void setUpdatedbyTenant(String updatedbyTenant) {
 		this.updatedbyTenant = updatedbyTenant;
+	}
+
+	public boolean isHasChildren() {
+		return hasChildren;
+	}
+
+	public void setHasChildren(boolean hasChildren) {
+		this.hasChildren = hasChildren;
 	}
 }

--- a/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/model/SkRole.java
+++ b/tapis-securitylib/src/main/java/edu/utexas/tacc/tapis/security/authz/model/SkRole.java
@@ -220,7 +220,8 @@ public final class SkRole
         List<String> list = null;
         try {
             SkRoleDao dao = new SkRoleDao();
-            list = dao.getImmediatePermissions(tenant, id);
+            final boolean ordered = true;
+            list = dao.getImmediatePermissions(tenant, id, ordered);
         } catch (Exception e) {
             _log.error(e.getMessage()); // details already logged
             throw e;
@@ -329,7 +330,7 @@ public final class SkRole
 		this.updatedbyTenant = updatedbyTenant;
 	}
 
-	public boolean isHasChildren() {
+	public boolean hasChildren() {
 		return hasChildren;
 	}
 

--- a/tapis-securitymigrate/pom.xml
+++ b/tapis-securitymigrate/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>edu.utexas.tacc.tapis</groupId>
 		<artifactId>tapis-security</artifactId>
-		<version>1.6.0</version>
+		<version>1.6.1</version>
 	</parent>
 	
 	<artifactId>tapis-securitymigrate</artifactId>

--- a/tapis-securitymigrate/src/main/java/edu/utexas/tacc/tapis/flywaymigrations/V004__CalcHasChildren.java
+++ b/tapis-securitymigrate/src/main/java/edu/utexas/tacc/tapis/flywaymigrations/V004__CalcHasChildren.java
@@ -1,0 +1,46 @@
+package edu.utexas.tacc.tapis.flywaymigrations;
+
+import java.sql.PreparedStatement;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+/** When migrating an existing database after the introduction of the 
+ * has_children flag in role records, we need to set the flag on roles
+ * that do have children.
+ * 
+ * @author rcardone
+ */
+final public class V004__CalcHasChildren
+ extends BaseJavaMigration
+{
+	@Override
+	public void migrate(Context context) throws Exception 
+	{
+		// Announcement.
+		System.out.println("V004__CalcHasChildren starting.");
+		
+		// Set autocommit off.
+		var conn = context.getConnection();
+		conn.setAutoCommit(false);
+		
+		// Construct the update command that properly set the has_children flag
+		// from the default (false) to true when existing roles have children.
+		// If the subquery returns no parent roles then the update has no effect.
+		final String sql = 
+			"UPDATE sk_role SET has_children = ? " + 
+			"WHERE id IN (SELECT DISTINCT parent_role_id FROM sk_role_tree)";
+		
+		// Issue the update.
+		PreparedStatement pstmt = conn.prepareStatement(sql);
+		pstmt.setBoolean(1, true);
+        int rows = pstmt.executeUpdate();
+
+        // Commit the transaction.
+        pstmt.close();
+        conn.commit();
+        
+        // Result message.
+        System.out.println("V004__CalcHasChildren: " + rows + " updated.");
+	}
+}

--- a/tapis-securitymigrate/src/main/java/edu/utexas/tacc/tapis/flywaymigrations/V004__CalcHasChildren.java
+++ b/tapis-securitymigrate/src/main/java/edu/utexas/tacc/tapis/flywaymigrations/V004__CalcHasChildren.java
@@ -41,6 +41,6 @@ final public class V004__CalcHasChildren
         conn.commit();
         
         // Result message.
-        System.out.println("V004__CalcHasChildren: " + rows + " updated.");
+        System.out.println("V004__CalcHasChildren: " + rows + " roles updated.");
 	}
 }

--- a/tapis-securitymigrate/src/main/java/edu/utexas/tacc/tapis/securitymigrate/TapisSecurityJDBCMigrateParms.java
+++ b/tapis-securitymigrate/src/main/java/edu/utexas/tacc/tapis/securitymigrate/TapisSecurityJDBCMigrateParms.java
@@ -45,7 +45,7 @@ public final class TapisSecurityJDBCMigrateParms
  {
   // Override field default values set in superclass after 
   // construction but before we process user input.
-  cmdDirectory = "edu/utexas/tacc/tapis/securitymigrate/sql,classpath:edu/utexas/tacc/tapis/securitymigrate/scripts";
+  cmdDirectory = "edu/utexas/tacc/tapis/securitymigrate/sql,classpath:edu/utexas/tacc/tapis/flywaymigrations";
   schema = HikariDSGenerator.TAPIS_SEC_SCHEMA_NAME;
 
   // Get a command line parser to verify input.

--- a/tapis-securitymigrate/src/main/resources/edu/utexas/tacc/tapis/securitymigrate/sql/V003__RoleHasChildren.sql
+++ b/tapis-securitymigrate/src/main/resources/edu/utexas/tacc/tapis/securitymigrate/sql/V003__RoleHasChildren.sql
@@ -1,0 +1,91 @@
+-- This new column allows SK to run quicker when roles are known not to have children.
+ALTER TABLE sk_role ADD COLUMN IF NOT EXISTS has_children boolean NOT NULL DEFAULT FALSE;
+COMMENT ON COLUMN sk_role.has_children IS 'Child role indicator';
+
+-- Add has_children field auditing.  Replacing the funtion does not break its trigger.
+CREATE OR REPLACE FUNCTION audit_sk_role() RETURNS TRIGGER AS $$
+    BEGIN
+        --
+        -- Description fields are trimmed of whitespace at both ends and may be truncated
+        -- to fit inside the audit record.
+        --
+        IF (TG_OP = 'DELETE') THEN
+            INSERT INTO sk_role_audit (refid, refname, refcol, change, oldvalue) 
+                VALUES (OLD.id, OLD.name, 'ALL', 'delete', 
+                        substring(trim(both ' \b\n\r' from OLD.description) from 1 for 512));
+            RETURN OLD;
+        ELSIF (TG_OP = 'UPDATE') THEN
+            -- We always use the OLD id and, when applicable, OLD name in update audit records, 
+            -- even if those fields are among those that have changed.  Any update that changes  
+            -- any field will cause an audit record to be written.  Since the updated timestamp 
+            -- always changes, updates typically cause 2 or more new audit records.   
+            IF OLD.id != NEW.id THEN
+                INSERT INTO sk_role_audit (refid, refname, refcol, change, oldvalue, newvalue) 
+                    VALUES (OLD.id, OLD.name, 'id', 'update', OLD.id::text, NEW.id::text);
+            END IF;
+            IF OLD.tenant != NEW.tenant THEN
+                INSERT INTO sk_role_audit (refid, refname, refcol, change, oldvalue, newvalue) 
+                    VALUES (OLD.id, OLD.name, 'tenant', 'update', OLD.tenant, NEW.tenant);
+            END IF;
+            IF OLD.name != NEW.name THEN
+                INSERT INTO sk_role_audit (refid, refname, refcol, change, oldvalue, newvalue) 
+                    VALUES (OLD.id, OLD.name, 'name', 'update', OLD.name, NEW.name);
+            END IF;
+            IF OLD.description != NEW.description THEN
+                INSERT INTO sk_role_audit (refid, refname, refcol, change, oldvalue, newvalue) 
+                    VALUES (OLD.id, OLD.name, 'description', 'update', 
+                            substring(trim(both ' \b\n\r' from OLD.description) from 1 for 512), 
+                            substring(trim(both ' \b\n\r' from NEW.description) from 1 for 512));
+            END IF;
+            IF OLD.owner != NEW.owner THEN
+                INSERT INTO sk_role_audit (refid, refname, refcol, change, oldvalue, newvalue) 
+                    VALUES (OLD.id, OLD.name, 'owner', 'update', OLD.owner, NEW.owner);
+            END IF;
+            IF OLD.owner_tenant != NEW.owner_tenant THEN
+                INSERT INTO sk_role_audit (refid, refname, refcol, change, oldvalue, newvalue) 
+                    VALUES (OLD.id, OLD.name, 'owner_tenant', 'update', OLD.owner_tenant, NEW.owner_tenant);
+            END IF;
+            IF OLD.createdby != NEW.createdby THEN
+                INSERT INTO sk_role_audit (refid, refname, refcol, change, oldvalue, newvalue) 
+                    VALUES (OLD.id, OLD.name, 'createdby', 'update', OLD.createdby, NEW.createdby);
+            END IF;
+            IF OLD.createdby_tenant != NEW.createdby_tenant THEN
+                INSERT INTO sk_role_audit (refid, refname, refcol, change, oldvalue, newvalue) 
+                    VALUES (OLD.id, OLD.name, 'createdby_tenant', 'update', OLD.createdby_tenant, NEW.createdby_tenant);
+            END IF;
+            IF OLD.updatedby != NEW.updatedby THEN
+                INSERT INTO sk_role_audit (refid, refname, refcol, change, oldvalue, newvalue) 
+                    VALUES (OLD.id, OLD.name, 'updatedby', 'update', OLD.updatedby, NEW.updatedby);
+            END IF;
+            IF OLD.updatedby_tenant != NEW.updatedby_tenant THEN
+                INSERT INTO sk_role_audit (refid, refname, refcol, change, oldvalue, newvalue) 
+                    VALUES (OLD.id, OLD.name, 'updatedby_tenant', 'update', OLD.updatedby_tenant, NEW.updatedby_tenant);
+            END IF;
+            IF OLD.created != NEW.created THEN
+                INSERT INTO sk_role_audit (refid, refname, refcol, change, oldvalue, newvalue) 
+                    VALUES (OLD.id, OLD.name, 'created', 'update', 
+                            OLD.created::text, 
+                            NEW.created::text);
+            END IF;
+            IF OLD.updated != NEW.updated THEN
+                INSERT INTO sk_role_audit (refid, refname, refcol, change, oldvalue, newvalue) 
+                    VALUES (OLD.id, OLD.name, 'updated', 'update', 
+                            OLD.updated::text, 
+                            NEW.updated::text);
+            END IF;
+            IF OLD.has_children != NEW.has_children THEN
+                INSERT INTO sk_role_audit (refid, refname, refcol, change, oldvalue, newvalue) 
+                    VALUES (OLD.id, OLD.name, 'has_children', 'update', OLD.has_children, NEW.has_children);
+            END IF;
+
+            RETURN NEW;
+        ELSIF (TG_OP = 'INSERT') THEN
+            INSERT INTO sk_role_audit (refid, refname, refcol, change, newvalue) 
+                VALUES (NEW.id, NEW.name, 'ALL', 'insert', 
+                        substring(trim(both ' \b\n\r' from NEW.description) from 1 for 512));
+            RETURN NEW;
+        END IF;
+        RETURN NULL; -- result is ignored since this is an AFTER trigger
+    END;
+$$ LANGUAGE plpgsql;
+


### PR DESCRIPTION
Added the _**has_children**_ flag to role records in sk_roles to avoid more expensive recursive queries.  The database schema required a java migration script to be run in flyway to assign existing roles their proper has_children value.  In addition, SK code must use the new field to conditionally substitute simple queries for recursive queries when a role does not have children. 